### PR TITLE
Update to angular version and move of mocks

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,9 +7,11 @@
   "readmeFilename"  : "README.md",
   "main"            : "message-center.js",
   "dependencies"    : {
-    "angular"       : ">=1.2.0 <1.4.0",
-    "angular-route" : ">=1.2.0 <1.4.0",
-    "angular-mocks" : ">=1.2.0 <1.4.0"
+    "angular"       : ">=1.2.0 <1.5.0",
+    "angular-route" : ">=1.2.0 <1.5.0"
+  },
+  "devDependencies" : {
+    "angular-mocks" : ">=1.2.0 <1.5.0"
   },
   "ignore"          : [ "**/.*", "node_modules", "test" ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-center",
-  "version": "1.1.4",
+  "version": "1.2.4",
   "description": "AngularJS Message Center",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Move angular-mocks to devDependencies and update angular and angular-route to allow up to version 1.5.0.

Closes #28, closes #25