### PR TITLE
Bugfix: Close unclosed span tag to prevend error in Internet Explorer 8

### DIFF
--- a/message-center.js
+++ b/message-center.js
@@ -106,11 +106,12 @@ MessageCenterModule.
       <div class="alert alert-{{ message.type }} {{ animation }}" ng-repeat="message in mcMessages">\
         <a class="close" ng-click="message.close();" data-dismiss="alert" aria-hidden="true">&times;</a>\
         <span ng-switch on="message.html">\
-        <span ng-switch-when="true">\
-          <span ng-bind-html="message.message"></span>\
-        </span>\
-        <span ng-switch-default>\
-          {{ message.message }}\
+          <span ng-switch-when="true">\
+            <span ng-bind-html="message.message"></span>\
+          </span>\
+          <span ng-switch-default>\
+            {{ message.message }}\
+          </span>\
         </span>\
       </div>\
     </div>\


### PR DESCRIPTION
IE8 can't handle the unclosed span tag. It will fail with with the JavaScript error message `Error: [$compile:ctreq] Controller 'ngSwitch', required by directive 'ngSwitchDefault', can't be found!
http://errors.angularjs.org/1.2.29/$compile/ctreq?p0=ngSwitch&p1=ngSwitchDefault`