### PR TITLE
Remove deprecated version from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name"            : "message-center",
-  "version"         : "1.1.3",
   "description"     : "AngularJS Message Center",
   "keywords"        : [ "angular", "js", "messages", "alert", "bootstrap" ],
   "author"          : "Mateu Aguiló Bosch <mateu.aguilo.bosch@gmail.com>",


### PR DESCRIPTION
https://github.com/bower/spec/blob/master/json.md#version

Since this is behind tags, `bower install` complains:
```bash
bower message-center#~1.2.5                    mismatch Version declared in the json (1.1.3) is different than the resolved one (1.2.5)
```