### PR TITLE
Bugfix: $messageCenterService.options are overwritten

### DIFF
--- a/message-center.js
+++ b/message-center.js
@@ -43,7 +43,7 @@ MessageCenterModule
           var availableTypes = ['info', 'warning', 'danger', 'success'],
             service = this;
           options = options || {};
-          var options = angular.extend($messageCenterService.getOptions(), options);
+          var options = angular.extend({}, $messageCenterService.getOptions(), options);
           if (availableTypes.indexOf(type) == -1) {
             throw "Invalid message type";
           }


### PR DESCRIPTION
If messageCenterService.add is called then $messageCenterService.options can be overwritten. Angular extend copies properties from source to destination. This can be prevented by passing an empty object as the target.

https://docs.angularjs.org/api/ng/function/angular.extend
